### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-nx7seg KEYWORD1
+nx7seg	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-nx7seg KEYWORD2
-buffer KEYWORD2
-clear KEYWORD2
-send KEYWORD2
-cypher KEYWORD2
-refresh KEYWORD2
-write KEYWORD2
-writeChar KEYWORD2
-writeDigit KEYWORD2
-writeFloat KEYWORD2
-writeInt KEYWORD2
+nx7seg	KEYWORD2
+buffer	KEYWORD2
+clear	KEYWORD2
+send	KEYWORD2
+cypher	KEYWORD2
+refresh	KEYWORD2
+write	KEYWORD2
+writeChar	KEYWORD2
+writeDigit	KEYWORD2
+writeFloat	KEYWORD2
+writeInt	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords